### PR TITLE
Update gulpfile and package.json to support code documentation 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,3 +155,22 @@ gulp.task('default', ['server:start'], function(){
     gulp.run('server:restart');
   });
 });
+
+gulp.task('doc', function(done){
+  var jsdoc = require('gulp-jsdoc');
+  var rimraf = require('rimraf');
+
+  rimraf('./doc/dist', function(err){
+    if (err) {
+      done(err);
+    }
+    gulp.src([
+      './server/**/*.js',
+      './client/spa/js/**/*.js',
+      'README.md'])
+      .pipe(jsdoc.parser({plugins: ['plugins/markdown']}))
+      .pipe(jsdoc.generator('./doc/dist'));
+    done();
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp": "^3.8.10",
     "gulp-develop-server": "^0.2.5",
     "gulp-jasmine": "^2.0.0",
+    "gulp-jsdoc": "^0.1.4",
     "gulp-jshint": "^1.9.0",
     "gulp-sequence": "^0.3.1",
     "gulp-util": "^3.0.2",
@@ -53,6 +54,7 @@
     "karma-browserify": "^2.0.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
+    "rimraf": "^2.2.8",
     "strongloop": "^2.10.2"
   }
 }


### PR DESCRIPTION
You'll need to run `npm install` to get install the dependencies for the gulp task.

Use `gulp doc` to generate the documentation.
